### PR TITLE
[T-8852][15.0][FIX] crm_autoassign: Fix autoassign query

### DIFF
--- a/crm_autoassign/models/crm_team.py
+++ b/crm_autoassign/models/crm_team.py
@@ -39,8 +39,8 @@ class Team(models.Model):
         action_id = self.env.ref("crm_autoassign.crm_autoassign_cron")
         try:
             self._cr.execute(
-                "SELECT id FROM ir_cron WHERE id IN %s FOR UPDATE NOWAIT",
-                (tuple([action_id.id])),
+                "SELECT id FROM ir_cron WHERE id = %s FOR UPDATE NOWAIT",
+                (action_id.id,),
             )
         except psycopg2.OperationalError:
             raise UserError(


### PR DESCRIPTION
@HaraldPanten @ValentinVinagre 

Fix query error in autoassign: 
<img width="2980" height="1796" alt="image" src="https://github.com/user-attachments/assets/fa552b4a-7a38-4987-adc1-68766e4208ae" />
`Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 242, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 702, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 368, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 357, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 925, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 546, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1328, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1316, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 471, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 456, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/crm_autoassign/models/crm_team.py", line 41, in action_autoassign_opportunities
    self._cr.execute(
  File "<decorator-gen-5>", line 2, in execute
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 90, in check
    return f(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 311, in execute
    res = self._obj.execute(query, params)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 658, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
psycopg2.errors.SyntaxError: syntax error at or near "22"
LINE 1: SELECT id FROM ir_cron WHERE id IN 22 FOR UPDATE NOWAIT`